### PR TITLE
added admin interface prototype & routes for admin pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ var bodyParser = require('body-parser');
 var routes = require('./routes/index');
 var user = require('./routes/controller/user');
 var problem = require('./routes/controller/problem');
+var admin = require('./routes/controller/admin');
 
 var app = express();
 
@@ -28,6 +29,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use('/', routes);
 app.use('/user',user);
 app.use('/problem',problem);
+app.use('/admin',admin);
 
 
 // catch 404 and forward to error handler

--- a/routes/controller/admin.js
+++ b/routes/controller/admin.js
@@ -1,0 +1,26 @@
+var express = require('express');
+var router = express.Router();
+
+router.get('/', function(req, res, next) {
+  res.render('admin/notice', { title: '公告管理' });
+});
+router.get('/notice', function(req, res, next) {
+  res.render('admin/notice', { title: '公告管理' });
+});
+router.get('/contest', function(req, res, next) {
+  res.render('admin/contest', { title: '比赛管理'});
+});
+router.get('/problem', function(req, res, next) {
+  res.render('admin/problem', { title: '题目管理'});
+})
+router.get('/edit/notice', function(req, res, next) {
+  res.render('admin/edit_notice', { title: '编辑公告'});
+})
+router.get('/edit/contest', function(req, res, next) {
+  res.render('admin/edit_contest', { title: '编辑比赛'});
+})
+router.get('/edit/problem', function(req, res, next) {
+  res.render('admin/edit_problem', { title: '编辑题目'});
+})
+
+module.exports = router;

--- a/views/admin/contest.jade
+++ b/views/admin/contest.jade
@@ -1,0 +1,63 @@
+extends ./layout_nav
+
+block content
+  .row
+    .col-md-8.col-md-offset-2
+      h2 管理站点-#{title}
+      ul.nav.nav-tabs
+        li(role="presentation")
+          a(href="/admin/notice") 公告
+        li.active(role="presentation")
+          a(href="/admin/contest") 比赛
+        li(role="presentation")
+          a(href="/admin/problem") 题目
+      br
+      p
+        a.btn.btn-success(href="/admin/edit/contest") 新建比赛
+      .panel.panel-default
+        .panel-body 共计#场比赛
+      .panel.panel-default
+        table.table.table-hover.table-striped
+          thead
+            tr
+              th #
+              th 比赛
+              th 开始时间
+              th 结束时间
+              th 状态
+              th 操作
+          tbody
+            tr
+              td 3
+              td 
+                a(href="") NWPU-Weekly-03
+              td 2016/10/5 20:00
+              td 2016/10/5 22:00
+              td 未开始
+              td 
+                a(href="/admin/edit/contest") 修改
+                span &nbsp;&nbsp;
+                a(href="") 删除
+            tr
+              td 2
+              td 
+                a(href="") NWPU-Weekly-02
+              td 2016/10/3 20:00
+              td 2016/10/3 22:00
+              td 已结束
+              td 
+                a(href="/admin/edit/contest") 修改
+                span &nbsp;&nbsp;
+                a(href="") 删除
+            tr
+              td 1
+              td 
+                a(href="") NWPU-Weekly-01
+              td 2016/10/1 20:00
+              td 2016/10/1 22:00
+              td 已结束
+              td 
+                a(href="/admin/edit/contest") 修改
+                span &nbsp;&nbsp;
+                a(href="") 删除
+          

--- a/views/admin/edit_contest.jade
+++ b/views/admin/edit_contest.jade
@@ -1,0 +1,89 @@
+extends ./layout_nav
+
+block content
+  .row
+    .col-md-8.col-md-offset-2
+      h2 #{title}
+      hr
+      form(role='form')
+        .row
+          .col-md-6
+            .form-group
+              label(for="title") 比赛标题
+              input.form-control(name="title" type='text')
+            .form-group
+              label(for="group") 比赛权限
+              label.checkbox-inline
+                input(type="radio" name="group" value="all" checked) 
+                全部用户组
+              label.checkbox-inline
+                input(type="radio" name="group" value="limited") 
+                指定用户组
+            .form-group
+              label(for="appendix") 附加信息
+              textarea.form-control(name='appendix' rows='3')
+          .col-md-6
+            .form-group
+              label(for="problemlist") 题目清单
+              table.table.table-striped
+                thead
+                  tr
+                    th(width="40px;")
+                      a.btn.btn-success.btn-sm.add_btn
+                        添加
+                    th(width="40%") #
+                    th 标题
+                tbody#problemList
+                  tr#problemListTemplate
+                    td
+                      a.btn.btn-danger.btn-sm.del_btn
+                        删除
+                    td
+                      input.form-control.input-sm(type='text')
+                    td.problemTitle 测试01
+              
+        hr
+        p
+          a.pull-right.btn.btn-danger(href="#") 删除该比赛
+          span.pull-right &nbsp; &nbsp;
+          a.pull-right.btn.btn-primary( href="/admin/notice") 放弃编辑
+          button.btn.btn-success(type='submit') 提交
+
+  script.
+    var cnt=1;
+    // contestListInit
+    var cLstTemplate=$("#problemListTemplate");
+    cLstTemplate.hide();
+
+    // drag function
+    var fixHelper=function(e, ui) {
+      ui.children().each(function() {
+        $(this).width($(this).width());
+      });
+      return ui;
+    };
+
+    $(function() {
+      $("#problemList").sortable({
+        helper: fixHelper,
+        axis: "y"
+      });
+      //$("#problemList").disableSelection();
+    });
+    
+    // add problem
+    $(".add_btn").click(function() {
+      var nLstItem=cLstTemplate.clone();
+      nLstItem.attr("id", "");
+      nLstItem.attr("class", "problemItem");
+      nLstItem.attr("style", "");
+      nLstItem.find(".problemTitle").text("测试"+cnt);
+      cnt+=1;
+      $("#problemList").append(nLstItem);
+    });
+
+    // delete problem
+    $("body").on("click", ".del_btn", function() {
+      //alert($(this).parent().parent().attr("class"));
+      $(this).parent().parent().remove();
+    });

--- a/views/admin/edit_notice.jade
+++ b/views/admin/edit_notice.jade
@@ -1,0 +1,20 @@
+extends ./layout_nav
+
+block content
+  .row
+    .col-md-8.col-md-offset-2
+      h2 #{title}
+      hr
+      form(role='form')
+        p
+          input.form-control(name='title' type='text' placeholder="请输入标题")
+        p
+          textarea.form-control(name='content' rows='3' placeholder='请输入内容')
+        hr
+        p
+          a.pull-right.btn.btn-danger(href="#") 删除此条公告
+          span.pull-right &nbsp; &nbsp;
+          a.pull-right.btn.btn-primary( href="/admin/notice") 放弃编辑
+          button.btn.btn-success(type='submit') 提交
+        
+          

--- a/views/admin/edit_problem.jade
+++ b/views/admin/edit_problem.jade
@@ -1,0 +1,23 @@
+extends ./layout_nav
+
+block content
+  .row
+    .col-md-8.col-md-offset-2
+      h2 #{title}
+      hr
+      form(role='form')
+        .form-group
+          label(for="title") 题目标题
+          input.form-control(name="title" type='text')
+        .form-group
+          label(for="appendix") 题目描述
+          textarea.form-control(name='appendix' rows='3')
+              
+        hr
+        p
+          a.pull-right.btn.btn-danger(href="#") 删除该比赛
+          span.pull-right &nbsp; &nbsp;
+          a.pull-right.btn.btn-primary( href="/admin/notice") 放弃编辑
+          button.btn.btn-success(type='submit') 提交
+        
+          

--- a/views/admin/layout_nav.jade
+++ b/views/admin/layout_nav.jade
@@ -1,0 +1,13 @@
+doctype html
+html
+  head
+    title=title
+    link(rel='stylesheet', href='/stylesheets/style.css')
+    link(rel='stylesheet', href='/bootstrap/css/bootstrap.min.css')
+    script(src="/jquery/jquery.min.js")
+    <script src="//cdn.bootcss.com/jqueryui/1.10.1/jquery-ui.min.js"></script>
+    script(src="/bootstrap/js/bootstrap.min.js")
+    script(src="/javascripts/angular.min.js")
+  body
+    include nav
+    block content

--- a/views/admin/nav.jade
+++ b/views/admin/nav.jade
@@ -1,0 +1,20 @@
+nav.navbar.navbar-default(role='navigation')
+  .container-fluid
+    // Brand and toggle get grouped for better mobile display
+    .navbar-header
+      button.navbar-toggle.collapsed(type='button', data-toggle='collapse', data-target='#bs-example-navbar-collapse-1')
+        span.sr-only Toggle navigation
+        span.icon-bar
+        span.icon-bar
+        span.icon-bar
+      a.navbar-brand(href='#') NPU_OJ
+    // Collect the nav links, forms, and other content for toggling
+    #bs-example-navbar-collapse-1.collapse.navbar-collapse
+      ul.nav.navbar-nav
+        li
+          a(href="/admin/") 管理站点
+      ul.nav.navbar-nav.navbar-right
+        li
+          a(href='/') 站点首页
+        li
+          a(href='#') 登出

--- a/views/admin/notice.jade
+++ b/views/admin/notice.jade
@@ -1,0 +1,40 @@
+extends ./layout_nav
+
+block content
+  .row
+    .col-md-8.col-md-offset-2
+      h2 管理站点-#{title}
+      ul.nav.nav-tabs
+        li.active(role="presentation")
+          a(href="/admin/notice") 公告
+        li(role="presentation")
+          a(href="/admin/contest") 比赛
+        li(role="presentation")
+          a(href="/admin/problem") 题目
+      br
+      p
+        a.btn.btn-success(href="/admin/edit/notice") 新建公告
+      .panel.panel-default
+        .panel-body 共计#条公告
+      .panel.panel-default
+        table.table.table-hover.tabel-striped
+          thead
+            tr
+              th #
+              th 标题
+              th 创建时间
+              th 最后修改
+              th 操作
+          tbody
+            tr
+              td 1
+              td 
+                a(href="") 测试01
+              td 2016/10/5 20:00
+              td 2016/10/5 22:00
+              td 
+                a(href="/admin/edit/notice") 修改
+                span &nbsp;&nbsp;
+                a(href="") 删除
+  
+          

--- a/views/admin/problem.jade
+++ b/views/admin/problem.jade
@@ -1,0 +1,37 @@
+extends ./layout_nav
+
+block content
+  .row
+    .col-md-8.col-md-offset-2
+      h2 管理站点-#{title}
+      ul.nav.nav-tabs
+        li(role="presentation")
+          a(href="/admin/notice") 公告
+        li(role="presentation")
+          a(href="/admin/contest") 比赛
+        li.active(role="presentation")
+          a(href="/admin/problem") 题目
+      br
+      p
+        a.btn.btn-success(href="/admin/edit/problem") 新建题目
+      .panel.panel-default
+        .panel-body 共计#个题目
+      .panel.panel-default
+        table.table.table-hover.tabel-striped
+          thead
+            tr
+              th #
+              th 标题
+              th 状态
+              th 操作
+          tbody
+            tr
+              td 1
+              td 
+                a(href="") A+B
+              td 243/244
+              td 
+                a(href="/admin/edit/problem") 修改
+                span &nbsp;&nbsp;
+                a(href="") 删除
+          


### PR DESCRIPTION
## 添加了admin路由

RT

## 管理员界面

- 管理公告
- 管理比赛
- 管理题目
- 新建公告页
    - 缺一个富文本编辑器
- 新建比赛页
    - 用JQueryUI做了一个可拖动的题目清单设置界面
- 新建题目页
    - 暂时不清楚新建题目的具体要输入的内容

运行服务器后访问 *localhost:3000/admin* 进入管理员页面，默认以公告管理作为首页。
